### PR TITLE
fix(typescript): import Logger type directly from graphile-worker

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,8 +8,9 @@ import {
   Runner as WorkerRunner,
   run as runWorker,
   runOnce as runWorkerOnce,
+  Logger,
 } from "graphile-worker";
-import { defaultLogger, Logger } from "graphile-worker/dist/logger";
+import { defaultLogger } from "graphile-worker/dist/logger";
 import upsertSchedule, { Schedule } from "./upsertSchedule";
 
 export interface ScheduleConfig extends Schedule {


### PR DESCRIPTION
Passing a Graphile logger to the scheduler constructor would give the following error:

```
Type 'import("/path/to/project/node_modules/graphile-worker/dist/logger").Logger' is not assignable to type 'import("/path/to/project/node_modules/graphile-scheduler/node_modules/graphile-worker/dist/logger").Logger'.
  Types have separate declarations of a private property '_scope'.ts(2322)
```

Sample code to reproduce:

```ts
import { LogFunctionFactory, Logger } from "graphile-worker";
import { run, Runner } from "graphile-scheduler";

import logger from "../logger";

const logFactory: LogFunctionFactory = scope => (level, message, meta) =>
  logger.log({ level, message, ...meta, ...scope });
const graphileLogger = new Logger(logFactory);

const scheduler: Runner = await run({
  pgPool: workerPool,
  logger: graphileLogger,
  schedules: [
    // ...
  ]
});

```