### PR TITLE
Schedules use timezone to determine when to run

### DIFF
--- a/sql/000001.sql
+++ b/sql/000001.sql
@@ -31,14 +31,14 @@ $$ language plpgsql;
 CREATE TABLE IF NOT EXISTS :GRAPHILE_SCHEDULER_SCHEMA."schedules" (
     "schedule_name" text,
     "last_checked" timestamp with time zone NOT NULL DEFAULT now(),
-
+    
     "minute" integer[] NOT NULL DEFAULT :GRAPHILE_SCHEDULER_SCHEMA.every_minute(),
     "hour" integer[] NOT NULL DEFAULT :GRAPHILE_SCHEDULER_SCHEMA.every_hour(),
     "day" integer[] NOT NULL DEFAULT :GRAPHILE_SCHEDULER_SCHEMA.every_day(),
     "month" integer[] NOT NULL DEFAULT :GRAPHILE_SCHEDULER_SCHEMA.every_month(),
     "dow" integer[] NOT NULL DEFAULT :GRAPHILE_SCHEDULER_SCHEMA.every_dow(),
     "timezone" TEXT NOT NULL CHECK (NOW() AT TIME ZONE timezone IS NOT NULL) DEFAULT current_setting('TIMEZONE'),
-
+    
     "task_identifier" text NOT NULL,
     "queue_name" text DEFAULT (public.gen_random_uuid())::text NOT NULL,
     "max_attempts" integer NOT NULL DEFAULT '25',
@@ -61,7 +61,7 @@ AS $$
 $$ LANGUAGE sql;
 
 
-CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.check_schedule(schedule_names text[] = NULL, starting_At TIMESTAMP WITH TIME ZONE = NULL, until TIMESTAMP WITH TIME ZONE = NOW())
+CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.check_schedule(schedule_names text[] = NULL, starting_At TIMESTAMP WITH TIME ZONE = NULL, until TIMESTAMP WITH TIME ZONE = NOW()) 
 RETURNS :GRAPHILE_SCHEDULER_SCHEMA.schedules
 AS $$
 DECLARE
@@ -76,7 +76,7 @@ BEGIN
     LIMIT 1
     FOR UPDATE OF schedules
     SKIP LOCKED;
-
+  
   IF v_schedule IS NULL THEN
     RETURN NULL;
   END IF;
@@ -85,17 +85,17 @@ BEGIN
 
   LOOP
     v_next_check := v_next_check + interval '1 minute';
-
-  	IF :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(v_schedule, v_next_check AT TIME ZONE v_schedule.timezone) THEN
+    
+  	IF :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(v_schedule, v_next_check) THEN
       PERFORM :GRAPHILE_WORKER_SCHEMA.add_job(
         identifier := v_schedule.task_identifier,
         payload := json_build_object('fireDate', date_trunc('minute', v_next_check)),
-        queue_name := v_schedule.queue_name,
-        run_at := date_trunc('minute', v_next_check),
+        queue_name := v_schedule.queue_name, 
+        run_at := date_trunc('minute', v_next_check), 
         max_attempts := v_schedule.max_attempts
       );
   	END IF;
-
+  	
     EXIT WHEN v_next_check > until;
   END LOOP ;
 
@@ -103,7 +103,7 @@ BEGIN
     SET last_checked = v_next_check
     WHERE schedule_name = v_schedule.schedule_name
     RETURNING * INTO v_schedule;
-
+    
   RETURN v_schedule;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,17 +1,17 @@
-DROP FUNCTION IF EXISTS :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(ebg_toolkit_cron.schedules,timestamp with time zone);
+DROP FUNCTION IF EXISTS :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time TIMESTAMP WITH TIME ZONE);
 
 -- Re-create function to use the schedule.timezone to check date portions in the schedule
-CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time_raw TIMESTAMP WITH TIME ZONE = NOW())
+CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time TIMESTAMP WITH TIME ZONE = NOW())
 RETURNS BOOLEAN
 AS $$
 DECLARE
-  v_check_time TIMESTAMP WITH TIME ZONE;
+  v_check_time_converted_tz TIMESTAMP WITH TIME ZONE;
 BEGIN
-  v_check_time := check_time_raw AT TIME ZONE schedule.timezone;
-  RETURN EXTRACT(minute FROM v_check_time) = ANY(schedule.minute)
-     AND EXTRACT(hour FROM v_check_time) = ANY(schedule.hour)
-     AND EXTRACT(day FROM v_check_time) = ANY(schedule.day)
-     AND EXTRACT(month FROM v_check_time) = ANY(schedule.month)
-     AND EXTRACT(dow FROM v_check_time) = ANY(schedule.dow);
+  v_check_time_converted_tz := check_time AT TIME ZONE schedule.timezone;
+  RETURN EXTRACT(minute FROM v_check_time_converted_tz) = ANY(schedule.minute)
+     AND EXTRACT(hour FROM v_check_time_converted_tz) = ANY(schedule.hour)
+     AND EXTRACT(day FROM v_check_time_converted_tz) = ANY(schedule.day)
+     AND EXTRACT(month FROM v_check_time_converted_tz) = ANY(schedule.month)
+     AND EXTRACT(dow FROM v_check_time_converted_tz) = ANY(schedule.dow);
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time_raw TIMESTAMP WITH TIME ZONE = NOW())
+RETURNS BOOLEAN
+AS $$
+DECLARE
+  v_check_time TIMESTAMP WITH TIME ZONE;
+BEGIN
+  v_check_time := check_time_raw AT TIME ZONE schedule.timezone;
+  RETURN EXTRACT(minute FROM v_check_time) = ANY(schedule.minute)
+     AND EXTRACT(hour FROM v_check_time) = ANY(schedule.hour)
+     AND EXTRACT(day FROM v_check_time) = ANY(schedule.day)
+     AND EXTRACT(month FROM v_check_time) = ANY(schedule.month)
+     AND EXTRACT(dow FROM v_check_time) = ANY(schedule.dow);
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,3 +1,6 @@
+DROP IF EXISTS FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(ebg_toolkit_cron.schedules,timestamp with time zone);
+
+-- Re-create function to use the schedule.timezone to check date portions in the schedule
 CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time_raw TIMESTAMP WITH TIME ZONE = NOW())
 RETURNS BOOLEAN
 AS $$

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,4 +1,4 @@
-DROP IF EXISTS FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(ebg_toolkit_cron.schedules,timestamp with time zone);
+DROP FUNCTION IF EXISTS :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(ebg_toolkit_cron.schedules,timestamp with time zone);
 
 -- Re-create function to use the schedule.timezone to check date portions in the schedule
 CREATE OR REPLACE FUNCTION :GRAPHILE_SCHEDULER_SCHEMA.schedules_matches(schedule :GRAPHILE_SCHEDULER_SCHEMA.schedules, check_time_raw TIMESTAMP WITH TIME ZONE = NOW())


### PR DESCRIPTION
Re-create the function `schedule_matches` via a new migration to have it use the `check_time` converted to the schedule's `timezone` when extracting data/time components

You may wanna squash commits when you merge as there were some irrelevant ones along the way ;-)

Fixes #11 